### PR TITLE
fix: resolve codeType to internal id in types get/update/export

### DIFF
--- a/src/commands/types/export.ts
+++ b/src/commands/types/export.ts
@@ -4,6 +4,7 @@ import {existsSync, statSync, writeFileSync} from 'node:fs'
 import {BaseCommand} from '../../base-command.js'
 import {createClient} from '../../client.js'
 import {outputError, outputJson, outputSuccess, setForceJson} from '../../output.js'
+import {resolveDocumentTypeId} from '../../resolve-type.js'
 
 export default class TypesExport extends BaseCommand {
   static args = {
@@ -31,7 +32,8 @@ export default class TypesExport extends BaseCommand {
 
     try {
       const client = createClient()
-      const result = await client.documentTypes.get(args.code)
+      const id = await resolveDocumentTypeId(client, args.code)
+      const result = await client.documentTypes.get(id)
 
       if (flags.output) {
         if (existsSync(flags.output) && statSync(flags.output).isDirectory()) {

--- a/src/commands/types/get.ts
+++ b/src/commands/types/get.ts
@@ -3,6 +3,7 @@ import {Args, Flags} from '@oclif/core'
 import {BaseCommand} from '../../base-command.js'
 import {createClient} from '../../client.js'
 import {outputError, outputKeyValue, setForceJson} from '../../output.js'
+import {resolveDocumentTypeId} from '../../resolve-type.js'
 
 export default class TypesGet extends BaseCommand {
   static args = {
@@ -27,7 +28,8 @@ export default class TypesGet extends BaseCommand {
 
     try {
       const client = createClient()
-      const result = await client.documentTypes.get(args.code)
+      const id = await resolveDocumentTypeId(client, args.code)
+      const result = await client.documentTypes.get(id)
 
       outputKeyValue(result, [
         {key: 'Code', value: result.codeType},

--- a/src/commands/types/update.ts
+++ b/src/commands/types/update.ts
@@ -5,6 +5,7 @@ import {BaseCommand} from '../../base-command.js'
 import {createClient} from '../../client.js'
 import {outputError, outputKeyValue, outputSuccess, setForceJson} from '../../output.js'
 import {parseSchema} from '../../parse-schema.js'
+import {resolveDocumentTypeId} from '../../resolve-type.js'
 
 export default class TypesUpdate extends BaseCommand {
   static args = {
@@ -55,7 +56,8 @@ export default class TypesUpdate extends BaseCommand {
       }
 
       const client = createClient()
-      const result = await client.documentTypes.update(args.code, params)
+      const id = await resolveDocumentTypeId(client, args.code)
+      const result = await client.documentTypes.update(id, params)
 
       outputKeyValue(result, [
         {key: 'Code', value: result.codeType},

--- a/src/resolve-type.ts
+++ b/src/resolve-type.ts
@@ -2,7 +2,7 @@ import type DocuTray from 'docutray'
 
 /**
  * Resolves a document type identifier (codeType or internal id) to an internal id.
- * If the input looks like an internal id (c + 24 alphanumeric chars), returns it directly.
+ * If the input looks like an internal id (c + 24 lowercase alphanumeric chars), returns it directly.
  * Otherwise, searches by codeType and returns the matching id.
  */
 export async function resolveDocumentTypeId(client: DocuTray, identifier: string): Promise<string> {
@@ -10,14 +10,25 @@ export async function resolveDocumentTypeId(client: DocuTray, identifier: string
     return identifier
   }
 
-  const result = await client.documentTypes.list({search: identifier})
-  const match = result.data.find(
-    (dt: {codeType: string; id: string}) => dt.codeType === identifier,
-  )
+  const limit = 100
+  let page = 1
 
-  if (!match) {
-    throw new Error(`Document type "${identifier}" not found`)
+  while (true) {
+    const result = await client.documentTypes.list({search: identifier, page, limit})
+    const match = result.data.find(
+      (dt: {codeType: string; id: string}) => dt.codeType === identifier,
+    )
+
+    if (match) {
+      return match.id
+    }
+
+    if (result.data.length < limit) {
+      break
+    }
+
+    page += 1
   }
 
-  return match.id
+  throw new Error(`Document type "${identifier}" not found`)
 }

--- a/src/resolve-type.ts
+++ b/src/resolve-type.ts
@@ -1,0 +1,23 @@
+import type DocuTray from 'docutray'
+
+/**
+ * Resolves a document type identifier (codeType or internal id) to an internal id.
+ * If the input looks like an internal id (c + 24 alphanumeric chars), returns it directly.
+ * Otherwise, searches by codeType and returns the matching id.
+ */
+export async function resolveDocumentTypeId(client: DocuTray, identifier: string): Promise<string> {
+  if (/^c[a-z0-9]{24}$/.test(identifier)) {
+    return identifier
+  }
+
+  const result = await client.documentTypes.list({search: identifier})
+  const match = result.data.find(
+    (dt: {codeType: string; id: string}) => dt.codeType === identifier,
+  )
+
+  if (!match) {
+    throw new Error(`Document type "${identifier}" not found`)
+  }
+
+  return match.id
+}

--- a/test/commands/types/export.test.ts
+++ b/test/commands/types/export.test.ts
@@ -22,6 +22,9 @@ function mockClient() {
   const client = {
     documentTypes: {
       get: vi.fn().mockResolvedValue({codeType: 'invoice', name: 'Invoice', fields: []}),
+      list: vi.fn().mockResolvedValue({
+        data: [{codeType: 'invoice', id: 'cmnp1nxdb004s01tm5gxakfdl', name: 'Invoice'}],
+      }),
     },
   }
   mockCreateClient.mockReturnValue(client as any)
@@ -41,6 +44,13 @@ describe('types export --force', () => {
     exitSpy = vi.spyOn(TypesExport.prototype, 'exit').mockImplementation(() => {
       throw new Error('EXIT')
     })
+  })
+
+  it('resolves codeType to id before calling get', async () => {
+    const client = mockClient()
+    await TypesExport.run(['invoice'])
+    expect(client.documentTypes.list).toHaveBeenCalledWith({search: 'invoice'})
+    expect(client.documentTypes.get).toHaveBeenCalledWith('cmnp1nxdb004s01tm5gxakfdl')
   })
 
   it('rejects overwriting existing file without --force', async () => {

--- a/test/commands/types/export.test.ts
+++ b/test/commands/types/export.test.ts
@@ -49,7 +49,7 @@ describe('types export --force', () => {
   it('resolves codeType to id before calling get', async () => {
     const client = mockClient()
     await TypesExport.run(['invoice'])
-    expect(client.documentTypes.list).toHaveBeenCalledWith({search: 'invoice'})
+    expect(client.documentTypes.list).toHaveBeenCalledWith({search: 'invoice', page: 1, limit: 100})
     expect(client.documentTypes.get).toHaveBeenCalledWith('cmnp1nxdb004s01tm5gxakfdl')
   })
 

--- a/test/commands/types/get.test.ts
+++ b/test/commands/types/get.test.ts
@@ -1,0 +1,83 @@
+import {describe, expect, it, vi, beforeEach} from 'vitest'
+
+vi.mock('../../../src/client.js', () => ({
+  createClient: vi.fn(),
+}))
+
+import {createClient} from '../../../src/client.js'
+import TypesGet from '../../../src/commands/types/get.js'
+
+const mockCreateClient = vi.mocked(createClient)
+
+function mockClient() {
+  const client = {
+    documentTypes: {
+      get: vi.fn().mockResolvedValue({
+        codeType: 'invoice',
+        description: 'Standard invoice',
+        fields: [{name: 'total'}],
+        isDraft: false,
+        isPublic: true,
+        name: 'Invoice',
+      }),
+      list: vi.fn().mockResolvedValue({
+        data: [{codeType: 'invoice', id: 'cmnp1nxdb004s01tm5gxakfdl', name: 'Invoice'}],
+      }),
+    },
+  }
+  mockCreateClient.mockReturnValue(client as any)
+  return client
+}
+
+describe('types get', () => {
+  let stderrSpy: ReturnType<typeof vi.spyOn>
+  let stdoutSpy: ReturnType<typeof vi.spyOn>
+  let exitSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+    exitSpy = vi.spyOn(TypesGet.prototype, 'exit').mockImplementation(() => {
+      throw new Error('EXIT')
+    })
+  })
+
+  it('resolves codeType to id before calling get', async () => {
+    const client = mockClient()
+
+    await TypesGet.run(['invoice'])
+
+    expect(client.documentTypes.list).toHaveBeenCalledWith({search: 'invoice', page: 1, limit: 100})
+    expect(client.documentTypes.get).toHaveBeenCalledWith('cmnp1nxdb004s01tm5gxakfdl')
+  })
+
+  it('passes internal id directly without lookup', async () => {
+    const client = mockClient()
+
+    await TypesGet.run(['cmnp1nxdb004s01tm5gxakfdl'])
+
+    expect(client.documentTypes.list).not.toHaveBeenCalled()
+    expect(client.documentTypes.get).toHaveBeenCalledWith('cmnp1nxdb004s01tm5gxakfdl')
+  })
+
+  it('displays key-value output', async () => {
+    mockClient()
+
+    await TypesGet.run(['invoice'])
+
+    expect(stdoutSpy).toHaveBeenCalled()
+  })
+
+  it('shows error when codeType not found', async () => {
+    const client = mockClient()
+    client.documentTypes.list.mockResolvedValue({data: []})
+
+    await expect(TypesGet.run(['nonexistent'])).rejects.toThrow('EXIT')
+    const stderrOutput = stderrSpy.mock.calls.map(([msg]) => msg).join('')
+    expect(stderrOutput).toContain('Document type')
+    expect(stderrOutput).toContain('nonexistent')
+    expect(stderrOutput).toContain('not found')
+    exitSpy.mockRestore()
+  })
+})

--- a/test/commands/types/update.test.ts
+++ b/test/commands/types/update.test.ts
@@ -29,6 +29,9 @@ const mockResult = {
 function mockClient() {
   const client = {
     documentTypes: {
+      list: vi.fn().mockResolvedValue({
+        data: [{codeType: 'invoice', id: 'cmnp1nxdb004s01tm5gxakfdl', name: 'Invoice'}],
+      }),
       update: vi.fn().mockResolvedValue(mockResult),
     },
   }
@@ -56,7 +59,7 @@ describe('types update', () => {
 
     await TypesUpdate.run(['invoice', '--name', 'Updated Invoice'])
 
-    expect(client.documentTypes.update).toHaveBeenCalledWith('invoice', {name: 'Updated Invoice'})
+    expect(client.documentTypes.update).toHaveBeenCalledWith('cmnp1nxdb004s01tm5gxakfdl', {name: 'Updated Invoice'})
     expect(stdoutSpy).toHaveBeenCalled()
   })
 
@@ -69,7 +72,7 @@ describe('types update', () => {
     await TypesUpdate.run(['invoice', '--schema', 'new-schema.json'])
 
     expect(mockReadFileSync).toHaveBeenCalledWith('new-schema.json', 'utf8')
-    expect(client.documentTypes.update).toHaveBeenCalledWith('invoice', {
+    expect(client.documentTypes.update).toHaveBeenCalledWith('cmnp1nxdb004s01tm5gxakfdl', {
       jsonSchema: JSON.parse(schemaContent),
     })
   })
@@ -85,7 +88,7 @@ describe('types update', () => {
       '--conversion-mode', 'toon',
     ])
 
-    expect(client.documentTypes.update).toHaveBeenCalledWith('invoice', {
+    expect(client.documentTypes.update).toHaveBeenCalledWith('cmnp1nxdb004s01tm5gxakfdl', {
       conversionMode: 'toon',
       description: 'New description',
       name: 'New Name',
@@ -98,7 +101,7 @@ describe('types update', () => {
 
     await TypesUpdate.run(['invoice', '--publish'])
 
-    expect(client.documentTypes.update).toHaveBeenCalledWith('invoice', {isDraft: false})
+    expect(client.documentTypes.update).toHaveBeenCalledWith('cmnp1nxdb004s01tm5gxakfdl', {isDraft: false})
   })
 
   it('sets draft with --draft', async () => {
@@ -106,7 +109,7 @@ describe('types update', () => {
 
     await TypesUpdate.run(['invoice', '--draft'])
 
-    expect(client.documentTypes.update).toHaveBeenCalledWith('invoice', {isDraft: true})
+    expect(client.documentTypes.update).toHaveBeenCalledWith('cmnp1nxdb004s01tm5gxakfdl', {isDraft: true})
   })
 
   it('fails without any update flags', async () => {

--- a/test/resolve-type.test.ts
+++ b/test/resolve-type.test.ts
@@ -1,0 +1,62 @@
+import {describe, expect, it, vi} from 'vitest'
+
+import {resolveDocumentTypeId} from '../src/resolve-type.js'
+
+function mockClient(data: Array<{codeType: string; id: string}> = []) {
+  return {
+    documentTypes: {
+      list: vi.fn().mockResolvedValue({data}),
+    },
+  } as any
+}
+
+describe('resolveDocumentTypeId', () => {
+  it('passes through an internal id directly', async () => {
+    const client = mockClient()
+
+    const id = await resolveDocumentTypeId(client, 'cmnp1nxdb004s01tm5gxakfdl')
+
+    expect(id).toBe('cmnp1nxdb004s01tm5gxakfdl')
+    expect(client.documentTypes.list).not.toHaveBeenCalled()
+  })
+
+  it('resolves codeType to id via list search', async () => {
+    const client = mockClient([
+      {codeType: 'invoice', id: 'cmnp1nxdb004s01tm5gxakfdl'},
+    ])
+
+    const id = await resolveDocumentTypeId(client, 'invoice')
+
+    expect(id).toBe('cmnp1nxdb004s01tm5gxakfdl')
+    expect(client.documentTypes.list).toHaveBeenCalledWith({search: 'invoice'})
+  })
+
+  it('uses exact match when multiple results exist', async () => {
+    const client = mockClient([
+      {codeType: 'invoice-v2', id: 'other-id-0000000000000000'},
+      {codeType: 'invoice', id: 'cmnp1nxdb004s01tm5gxakfdl'},
+    ])
+
+    const id = await resolveDocumentTypeId(client, 'invoice')
+
+    expect(id).toBe('cmnp1nxdb004s01tm5gxakfdl')
+  })
+
+  it('throws when codeType is not found', async () => {
+    const client = mockClient([])
+
+    await expect(resolveDocumentTypeId(client, 'nonexistent')).rejects.toThrow(
+      'Document type "nonexistent" not found',
+    )
+  })
+
+  it('throws when no exact match exists among results', async () => {
+    const client = mockClient([
+      {codeType: 'invoice-v2', id: 'some-id-00000000000000000'},
+    ])
+
+    await expect(resolveDocumentTypeId(client, 'invoice')).rejects.toThrow(
+      'Document type "invoice" not found',
+    )
+  })
+})

--- a/test/resolve-type.test.ts
+++ b/test/resolve-type.test.ts
@@ -28,7 +28,7 @@ describe('resolveDocumentTypeId', () => {
     const id = await resolveDocumentTypeId(client, 'invoice')
 
     expect(id).toBe('cmnp1nxdb004s01tm5gxakfdl')
-    expect(client.documentTypes.list).toHaveBeenCalledWith({search: 'invoice'})
+    expect(client.documentTypes.list).toHaveBeenCalledWith({search: 'invoice', page: 1, limit: 100})
   })
 
   it('uses exact match when multiple results exist', async () => {
@@ -48,6 +48,28 @@ describe('resolveDocumentTypeId', () => {
     await expect(resolveDocumentTypeId(client, 'nonexistent')).rejects.toThrow(
       'Document type "nonexistent" not found',
     )
+  })
+
+  it('paginates to find match on a later page', async () => {
+    const firstPage = Array.from({length: 100}, (_, i) => ({
+      codeType: `type-${i}`,
+      id: `id-${i}-000000000000000000000`,
+    }))
+    const secondPage = [{codeType: 'invoice', id: 'cmnp1nxdb004s01tm5gxakfdl'}]
+
+    const client = {
+      documentTypes: {
+        list: vi.fn()
+          .mockResolvedValueOnce({data: firstPage})
+          .mockResolvedValueOnce({data: secondPage}),
+      },
+    } as any
+
+    const id = await resolveDocumentTypeId(client, 'invoice')
+
+    expect(id).toBe('cmnp1nxdb004s01tm5gxakfdl')
+    expect(client.documentTypes.list).toHaveBeenCalledTimes(2)
+    expect(client.documentTypes.list).toHaveBeenCalledWith({search: 'invoice', page: 2, limit: 100})
   })
 
   it('throws when no exact match exists among results', async () => {


### PR DESCRIPTION
## 🔗 Related Issue
Closes #21

## 📋 Changes Summary
- **New: `src/resolve-type.ts`** — shared `resolveDocumentTypeId(client, identifier)` helper that:
  - Returns internal ids directly if they match the `c` + 24 chars pattern
  - Otherwise calls `documentTypes.list({search})` and filters for exact `codeType` match
  - Throws a clear `Document type "xxx" not found` error when no match exists
- **`types get`**, **`types update`**, **`types export`** — integrated the resolver before SDK calls

## ✅ Acceptance Criteria
- [x] `types get <codeType>` resolves codeType to id before calling API
- [x] `types update <codeType>` resolves codeType to id before calling API
- [x] `types export <codeType>` resolves codeType to id before calling API
- [x] Internal ids (c + 24 chars) are passed through without lookup
- [x] Clear error message when codeType is not found
- [x] Exact codeType match used (not substring)

## 🧪 Testing
- 5 new unit tests for `resolveDocumentTypeId` (exact match, no match, id passthrough, multiple results, no exact match among results)
- Updated existing `types update` and `types export` tests to account for the resolver
- All 90 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)