### PR TITLE
fix: expose conversionId in convert --async and add --timeout flag (#22)

### DIFF
--- a/docs/commands/convert.md
+++ b/docs/commands/convert.md
@@ -11,7 +11,8 @@ Convert a document to structured data using a specified document type schema. Ac
 
 ```
 USAGE
-  $ docutray convert SOURCE -t <value> [--async] [--json] [--metadata <value>] [--webhook-url <value>]
+  $ docutray convert SOURCE -t <value> [--async] [--json] [--metadata <value>] [--timeout <value>]
+    [--webhook-url <value>]
 
 ARGUMENTS
   SOURCE  File path or URL to convert
@@ -21,6 +22,7 @@ FLAGS
       --async                Use async processing with polling (default: false). Status updates are emitted to stderr.
       --json                 Output as JSON (default when piped)
       --metadata=<value>     JSON metadata to attach to the conversion (e.g. '{"key":"value"}')
+      --timeout=<value>      [default: 300] Polling timeout in seconds for async processing (default: 300)
       --webhook-url=<value>  Webhook URL to receive a POST notification when conversion completes
 
 DESCRIPTION
@@ -41,6 +43,10 @@ EXAMPLES
 
     $ docutray convert invoice.pdf -t electronic-invoice --async
 
+  Async with 10-minute timeout for large documents
+
+    $ docutray convert large-doc.pdf -t electronic-invoice --async --timeout 600
+
   Convert with webhook notification on completion
 
     $ docutray convert receipt.jpg -t receipt --webhook-url https://example.com/hook
@@ -53,4 +59,4 @@ DOCUMENTATION
   Learn more: https://docs.docutray.com/cli/convert
 ```
 
-_See code: [src/commands/convert.ts](https://github.com/docutray/docutray-cli/blob/v0.1.2/src/commands/convert.ts)_
+_See code: [src/commands/convert.ts](https://github.com/docutray/docutray-cli/blob/v0.1.3/src/commands/convert.ts)_

--- a/docs/commands/identify.md
+++ b/docs/commands/identify.md
@@ -51,4 +51,4 @@ DOCUMENTATION
   Learn more: https://docs.docutray.com/cli/identify
 ```
 
-_See code: [src/commands/identify.ts](https://github.com/docutray/docutray-cli/blob/v0.1.2/src/commands/identify.ts)_
+_See code: [src/commands/identify.ts](https://github.com/docutray/docutray-cli/blob/v0.1.3/src/commands/identify.ts)_

--- a/docs/commands/login.md
+++ b/docs/commands/login.md
@@ -46,4 +46,4 @@ DOCUMENTATION
   Learn more: https://docs.docutray.com/cli/login
 ```
 
-_See code: [src/commands/login.ts](https://github.com/docutray/docutray-cli/blob/v0.1.2/src/commands/login.ts)_
+_See code: [src/commands/login.ts](https://github.com/docutray/docutray-cli/blob/v0.1.3/src/commands/login.ts)_

--- a/docs/commands/logout.md
+++ b/docs/commands/logout.md
@@ -34,4 +34,4 @@ DOCUMENTATION
   Learn more: https://docs.docutray.com/cli/logout
 ```
 
-_See code: [src/commands/logout.ts](https://github.com/docutray/docutray-cli/blob/v0.1.2/src/commands/logout.ts)_
+_See code: [src/commands/logout.ts](https://github.com/docutray/docutray-cli/blob/v0.1.3/src/commands/logout.ts)_

--- a/docs/commands/status.md
+++ b/docs/commands/status.md
@@ -38,4 +38,4 @@ DOCUMENTATION
   Learn more: https://docs.docutray.com/cli/status
 ```
 
-_See code: [src/commands/status.ts](https://github.com/docutray/docutray-cli/blob/v0.1.2/src/commands/status.ts)_
+_See code: [src/commands/status.ts](https://github.com/docutray/docutray-cli/blob/v0.1.3/src/commands/status.ts)_

--- a/docs/commands/steps.md
+++ b/docs/commands/steps.md
@@ -54,7 +54,7 @@ DOCUMENTATION
   Learn more: https://docs.docutray.com/cli/steps/run
 ```
 
-_See code: [src/commands/steps/run.ts](https://github.com/docutray/docutray-cli/blob/v0.1.2/src/commands/steps/run.ts)_
+_See code: [src/commands/steps/run.ts](https://github.com/docutray/docutray-cli/blob/v0.1.3/src/commands/steps/run.ts)_
 
 ## `docutray steps status EXECUTION-ID`
 
@@ -92,4 +92,4 @@ DOCUMENTATION
   Learn more: https://docs.docutray.com/cli/steps/status
 ```
 
-_See code: [src/commands/steps/status.ts](https://github.com/docutray/docutray-cli/blob/v0.1.2/src/commands/steps/status.ts)_
+_See code: [src/commands/steps/status.ts](https://github.com/docutray/docutray-cli/blob/v0.1.3/src/commands/steps/status.ts)_

--- a/docs/commands/types.md
+++ b/docs/commands/types.md
@@ -61,7 +61,7 @@ DOCUMENTATION
   Learn more: https://docs.docutray.com/cli/types/create
 ```
 
-_See code: [src/commands/types/create.ts](https://github.com/docutray/docutray-cli/blob/v0.1.2/src/commands/types/create.ts)_
+_See code: [src/commands/types/create.ts](https://github.com/docutray/docutray-cli/blob/v0.1.3/src/commands/types/create.ts)_
 
 ## `docutray types export CODE`
 
@@ -105,7 +105,7 @@ DOCUMENTATION
   Learn more: https://docs.docutray.com/cli/types/export
 ```
 
-_See code: [src/commands/types/export.ts](https://github.com/docutray/docutray-cli/blob/v0.1.2/src/commands/types/export.ts)_
+_See code: [src/commands/types/export.ts](https://github.com/docutray/docutray-cli/blob/v0.1.3/src/commands/types/export.ts)_
 
 ## `docutray types get CODE`
 
@@ -142,7 +142,7 @@ DOCUMENTATION
   Learn more: https://docs.docutray.com/cli/types/get
 ```
 
-_See code: [src/commands/types/get.ts](https://github.com/docutray/docutray-cli/blob/v0.1.2/src/commands/types/get.ts)_
+_See code: [src/commands/types/get.ts](https://github.com/docutray/docutray-cli/blob/v0.1.3/src/commands/types/get.ts)_
 
 ## `docutray types list`
 
@@ -188,7 +188,7 @@ DOCUMENTATION
   Learn more: https://docs.docutray.com/cli/types/list
 ```
 
-_See code: [src/commands/types/list.ts](https://github.com/docutray/docutray-cli/blob/v0.1.2/src/commands/types/list.ts)_
+_See code: [src/commands/types/list.ts](https://github.com/docutray/docutray-cli/blob/v0.1.3/src/commands/types/list.ts)_
 
 ## `docutray types update CODE`
 
@@ -241,4 +241,4 @@ DOCUMENTATION
   Learn more: https://docs.docutray.com/cli/types/update
 ```
 
-_See code: [src/commands/types/update.ts](https://github.com/docutray/docutray-cli/blob/v0.1.2/src/commands/types/update.ts)_
+_See code: [src/commands/types/update.ts](https://github.com/docutray/docutray-cli/blob/v0.1.3/src/commands/types/update.ts)_

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docutray/cli",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Official DocuTray CLI — AI-powered document processing from the command line",
   "author": "DocuTray",
   "license": "MIT",

--- a/src/commands/convert.ts
+++ b/src/commands/convert.ts
@@ -28,7 +28,7 @@ export default class Convert extends BaseCommand {
     async: Flags.boolean({default: false, description: 'Use async processing with polling (default: false). Status updates are emitted to stderr.'}),
     json: Flags.boolean({default: false, description: 'Output as JSON (default when piped)'}),
     metadata: Flags.string({description: 'JSON metadata to attach to the conversion (e.g. \'{"key":"value"}\')'}),
-    timeout: Flags.integer({default: 300, description: 'Polling timeout in seconds for async processing (default: 300)'}),
+    timeout: Flags.integer({default: 300, description: 'Polling timeout in seconds for async processing', min: 1}),
     type: Flags.string({char: 't', description: 'Document type code to use for extraction (see: docutray types list)', required: true}),
     'webhook-url': Flags.string({description: 'Webhook URL to receive a POST notification when conversion completes'}),
   }
@@ -74,8 +74,12 @@ export default class Convert extends BaseCommand {
           })
         } catch (error) {
           const msg = error instanceof Error ? error.message : String(error)
-          const enriched = new Error(`${msg} (conversionId: ${conversionId}). Use the conversion ID to check status later.`)
-          throw enriched
+          const isTimeout = msg.toLowerCase().includes('timeout') || msg.toLowerCase().includes('timed out')
+          if (isTimeout) {
+            throw new Error(`${msg} (conversionId: ${conversionId}). Use the conversion ID to check status later.`)
+          }
+
+          throw error
         }
 
         outputJson(result)

--- a/src/commands/convert.ts
+++ b/src/commands/convert.ts
@@ -19,6 +19,7 @@ export default class Convert extends BaseCommand {
     {command: '<%= config.bin %> convert invoice.pdf --type electronic-invoice', description: 'Convert a local PDF using a document type'},
     {command: '<%= config.bin %> convert https://example.com/doc.pdf -t electronic-invoice', description: 'Convert a document from a URL'},
     {command: '<%= config.bin %> convert invoice.pdf -t electronic-invoice --async', description: 'Use async processing with status polling'},
+    {command: '<%= config.bin %> convert large-doc.pdf -t electronic-invoice --async --timeout 600', description: 'Async with 10-minute timeout for large documents'},
     {command: '<%= config.bin %> convert receipt.jpg -t receipt --webhook-url https://example.com/hook', description: 'Convert with webhook notification on completion'},
     {command: '<%= config.bin %> convert invoice.pdf -t electronic-invoice --metadata \'{"ref":"order-123"}\'', description: 'Attach custom metadata to the conversion'},
   ]
@@ -27,6 +28,7 @@ export default class Convert extends BaseCommand {
     async: Flags.boolean({default: false, description: 'Use async processing with polling (default: false). Status updates are emitted to stderr.'}),
     json: Flags.boolean({default: false, description: 'Output as JSON (default when piped)'}),
     metadata: Flags.string({description: 'JSON metadata to attach to the conversion (e.g. \'{"key":"value"}\')'}),
+    timeout: Flags.integer({default: 300, description: 'Polling timeout in seconds for async processing (default: 300)'}),
     type: Flags.string({char: 't', description: 'Document type code to use for extraction (see: docutray types list)', required: true}),
     'webhook-url': Flags.string({description: 'Webhook URL to receive a POST notification when conversion completes'}),
   }
@@ -50,15 +52,32 @@ export default class Convert extends BaseCommand {
 
       if (flags.async) {
         const status = await client.convert.runAsync(params)
-        const result = await status.wait({
-          onStatus(s) {
-            if (isStderrInteractive()) {
-              process.stderr.write(`  Status: ${s.status}\n`)
-            } else {
-              process.stderr.write(JSON.stringify({status: s.status}) + '\n')
-            }
-          },
-        })
+        const conversionId = status.conversion_id
+
+        if (isStderrInteractive()) {
+          process.stderr.write(`⟳ Conversion ${conversionId}: ${status.status}\n`)
+        } else {
+          process.stderr.write(JSON.stringify({conversionId, status: status.status}) + '\n')
+        }
+
+        let result
+        try {
+          result = await status.wait({
+            onStatus(s) {
+              if (isStderrInteractive()) {
+                process.stderr.write(`⟳ Conversion ${conversionId}: ${s.status}\n`)
+              } else {
+                process.stderr.write(JSON.stringify({conversionId, status: s.status}) + '\n')
+              }
+            },
+            timeout: flags.timeout * 1000,
+          })
+        } catch (error) {
+          const msg = error instanceof Error ? error.message : String(error)
+          const enriched = new Error(`${msg} (conversionId: ${conversionId}). Use the conversion ID to check status later.`)
+          throw enriched
+        }
+
         outputJson(result)
       } else {
         const result = await client.convert.run(params)

--- a/test/__snapshots__/help.test.ts.snap
+++ b/test/__snapshots__/help.test.ts.snap
@@ -5,7 +5,7 @@ exports[`help output > convert --help output matches snapshot 1`] = `
 
 USAGE
   $ docutray convert SOURCE -t <value> [--async] [--json] [--metadata
-    <value>] [--webhook-url <value>]
+    <value>] [--timeout <value>] [--webhook-url <value>]
 
 ARGUMENTS
   SOURCE  File path or URL to convert
@@ -18,6 +18,8 @@ FLAGS
       --json                 Output as JSON (default when piped)
       --metadata=<value>     JSON metadata to attach to the conversion (e.g.
                              '{"key":"value"}')
+      --timeout=<value>      [default: 300] Polling timeout in seconds for async
+                             processing (default: 300)
       --webhook-url=<value>  Webhook URL to receive a POST notification when
                              conversion completes
 
@@ -40,6 +42,11 @@ EXAMPLES
   Use async processing with status polling
 
     $ docutray convert invoice.pdf -t electronic-invoice --async
+
+  Async with 10-minute timeout for large documents
+
+    $ docutray convert large-doc.pdf -t electronic-invoice --async --timeout \\
+      600
 
   Convert with webhook notification on completion
 

--- a/test/__snapshots__/help.test.ts.snap
+++ b/test/__snapshots__/help.test.ts.snap
@@ -19,7 +19,7 @@ FLAGS
       --metadata=<value>     JSON metadata to attach to the conversion (e.g.
                              '{"key":"value"}')
       --timeout=<value>      [default: 300] Polling timeout in seconds for async
-                             processing (default: 300)
+                             processing
       --webhook-url=<value>  Webhook URL to receive a POST notification when
                              conversion completes
 

--- a/test/commands/convert.test.ts
+++ b/test/commands/convert.test.ts
@@ -147,6 +147,40 @@ describe('convert --async', () => {
     exitSpy.mockRestore()
   })
 
+  it('prints TTY format with conversion_id when stderr is TTY', async () => {
+    const originalIsTTY = process.stderr.isTTY
+    process.stderr.isTTY = true
+    try {
+      mockClient()
+      await Convert.run(['file.pdf', '-t', 'inv', '--async'])
+      const stderrCalls = stderrSpy.mock.calls.map((c: any) => c[0] as string)
+      const ttyCall = stderrCalls.find((s: string) => s.includes('⟳ Conversion conv_abc123:'))
+      expect(ttyCall).toBeDefined()
+    } finally {
+      process.stderr.isTTY = originalIsTTY
+    }
+  })
+
+  it('rethrows non-timeout errors without wrapping', async () => {
+    const client = mockClient()
+    const apiError = Object.assign(new Error('Forbidden'), {statusCode: 403, body: {error: 'Forbidden'}, requestId: 'req-1'})
+    client.mockWait.mockRejectedValue(apiError)
+
+    const exitSpy = vi.spyOn(Convert.prototype, 'exit').mockImplementation(() => {
+      throw new Error('EXIT')
+    })
+
+    await expect(Convert.run(['file.pdf', '-t', 'inv', '--async', '--json'])).rejects.toThrow('EXIT')
+    // Verify outputError received the original error with its properties intact
+    expect(stderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Forbidden'),
+    )
+    expect(stderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining('req-1'),
+    )
+    exitSpy.mockRestore()
+  })
+
   it('includes conversion_id in JSON status output', async () => {
     const client = mockClient()
     client.mockWait.mockImplementation(async (opts: any) => {

--- a/test/commands/convert.test.ts
+++ b/test/commands/convert.test.ts
@@ -19,18 +19,20 @@ const mockExistsSync = vi.mocked(existsSync)
 const mockStatSync = vi.mocked(statSync)
 
 function mockClient() {
+  const mockWait = vi.fn().mockResolvedValue({id: 'conv-1', status: 'SUCCESS'})
   const client = {
     convert: {
       run: vi.fn().mockResolvedValue({id: 'conv-1', status: 'SUCCESS'}),
       runAsync: vi.fn().mockResolvedValue({
+        conversion_id: 'conv_abc123',
         id: 'conv-1',
         status: 'ENQUEUED',
-        wait: vi.fn().mockResolvedValue({id: 'conv-1', status: 'SUCCESS'}),
+        wait: mockWait,
       }),
     },
   }
   mockCreateClient.mockReturnValue(client as any)
-  return client
+  return {...client, mockWait}
 }
 
 describe('convert validation', () => {
@@ -91,5 +93,73 @@ describe('convert validation', () => {
     const client = mockClient()
     await Convert.run(['https://example.com/doc.pdf', '-t', 'inv'])
     expect(client.convert.run).toHaveBeenCalledWith(expect.objectContaining({url: 'https://example.com/doc.pdf'}))
+  })
+})
+
+describe('convert --async', () => {
+  let stderrSpy: ReturnType<typeof vi.spyOn>
+  let stdoutSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockExistsSync.mockReturnValue(true)
+    mockStatSync.mockReturnValue({isDirectory: () => false} as any)
+    stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+  })
+
+  it('prints conversion_id to stderr after runAsync', async () => {
+    mockClient()
+    await Convert.run(['file.pdf', '-t', 'inv', '--async', '--json'])
+    expect(stderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining('conv_abc123'),
+    )
+  })
+
+  it('passes --timeout value to wait() in milliseconds', async () => {
+    const {mockWait} = mockClient()
+    await Convert.run(['file.pdf', '-t', 'inv', '--async', '--timeout', '600', '--json'])
+    expect(mockWait).toHaveBeenCalledWith(
+      expect.objectContaining({timeout: 600_000}),
+    )
+  })
+
+  it('uses default 300s timeout', async () => {
+    const {mockWait} = mockClient()
+    await Convert.run(['file.pdf', '-t', 'inv', '--async', '--json'])
+    expect(mockWait).toHaveBeenCalledWith(
+      expect.objectContaining({timeout: 300_000}),
+    )
+  })
+
+  it('enriches timeout error with conversion_id', async () => {
+    const client = mockClient()
+    client.mockWait.mockRejectedValue(new Error('Polling timed out'))
+
+    const exitSpy = vi.spyOn(Convert.prototype, 'exit').mockImplementation(() => {
+      throw new Error('EXIT')
+    })
+
+    await expect(Convert.run(['file.pdf', '-t', 'inv', '--async', '--json'])).rejects.toThrow('EXIT')
+    expect(stderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining('conv_abc123'),
+    )
+    exitSpy.mockRestore()
+  })
+
+  it('includes conversion_id in JSON status output', async () => {
+    const client = mockClient()
+    client.mockWait.mockImplementation(async (opts: any) => {
+      opts.onStatus({status: 'PROCESSING'})
+      return {id: 'conv-1', status: 'SUCCESS'}
+    })
+
+    await Convert.run(['file.pdf', '-t', 'inv', '--async', '--json'])
+
+    const statusCalls = stderrSpy.mock.calls.map((c: any) => c[0] as string)
+    const jsonStatusCall = statusCalls.find((s: string) => s.includes('PROCESSING') && s.includes('conversionId'))
+    expect(jsonStatusCall).toBeDefined()
+    const parsed = JSON.parse(jsonStatusCall!)
+    expect(parsed).toEqual({conversionId: 'conv_abc123', status: 'PROCESSING'})
   })
 })


### PR DESCRIPTION
## Summary

- Print `conversion_id` to stderr immediately after `runAsync` returns (before polling starts) and in every polling status update
- Add `--timeout <seconds>` flag (default: 300) to control async polling duration, passed to SDK's `.wait()` in milliseconds
- Enrich timeout errors with `conversion_id` and recovery hint so users can check results later

## 🔗 Related Issue

Closes #22 (bundles #8 and #10)

## ✅ Acceptance Criteria

- [x] `conversion_id` printed to stderr immediately after `runAsync`
- [x] Each polling status update includes `conversion_id`
- [x] TTY format: `⟳ Conversion <id>: <STATUS>`
- [x] JSON format: `{"conversionId":"<id>","status":"<STATUS>"}`
- [x] Timeout error includes `conversion_id`
- [x] `--timeout <seconds>` flag controls polling timeout (default: 300)
- [x] Timeout value passed to SDK `.wait()` in milliseconds

## 🧪 Testing

- 5 new tests covering: conversion_id in stderr, timeout passed in ms, default timeout, enriched timeout error, JSON status output with conversionId
- All 100 tests passing
- Build successful

🤖 Generated with [Claude Code](https://claude.com/claude-code)