### PR TITLE
feat: implement OAuth2 authentication flow in login command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@docutray/cli",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@docutray/cli",
-      "version": "0.1.3",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "@docutray/cli",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@docutray/cli",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^4",
         "@oclif/plugin-autocomplete": "^3.2.45",
-        "docutray": "^0.1.2"
+        "docutray": "^0.1.2",
+        "open": "^11.0.0"
       },
       "bin": {
         "docutray": "bin/run.js"
@@ -3989,6 +3990,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -4250,6 +4266,34 @@
         "node": ">=6"
       }
     },
+    "node_modules/default-browser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/defer-to-connect": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
@@ -4258,6 +4302,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/detect-indent": {
@@ -4795,6 +4851,51 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-in-ssh": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
+      "integrity": "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container/node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -5162,6 +5263,26 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/open": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
+      "integrity": "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==",
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.4.0",
+        "define-lazy-prop": "^3.0.0",
+        "is-in-ssh": "^1.0.0",
+        "is-inside-container": "^1.0.0",
+        "powershell-utils": "^0.1.0",
+        "wsl-utils": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-cancelable": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-3.0.0.tgz",
@@ -5300,6 +5421,18 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/powershell-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
+      "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/proto-list": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
@@ -5409,6 +5542,18 @@
         "@rollup/rollup-win32-x64-gnu": "4.60.1",
         "@rollup/rollup-win32-x64-msvc": "4.60.1",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/safe-buffer": {
@@ -6129,6 +6274,37 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
+      "integrity": "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0",
+        "powershell-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/wsl-utils/node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/yoctocolors-cjs": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docutray/cli",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Official DocuTray CLI — AI-powered document processing from the command line",
   "author": "DocuTray",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
   "dependencies": {
     "@oclif/core": "^4",
     "@oclif/plugin-autocomplete": "^3.2.45",
-    "docutray": "^0.1.2"
+    "docutray": "^0.1.2",
+    "open": "^11.0.0"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -1,25 +1,36 @@
 import {Args, Flags} from '@oclif/core'
+import * as crypto from 'node:crypto'
 import * as readline from 'node:readline'
 
 import {BaseCommand} from '../base-command.js'
-import {getConfigPath, maskApiKey, readConfig, writeConfig} from '../config.js'
-import {outputError, outputSuccess, setForceJson} from '../output.js'
+import {type Config, getConfigPath, maskApiKey, readConfig, writeConfig} from '../config.js'
+import {
+  buildAuthorizeUrl,
+  createApiKeyFromToken,
+  exchangeCodeForToken,
+  extractOrgFromScope,
+  generatePKCE,
+  startCallbackServer,
+} from '../oauth.js'
+import {isStderrInteractive, outputError, outputSuccess, setForceJson} from '../output.js'
 
 export default class Login extends BaseCommand {
   static args = {
     'api-key': Args.string({description: 'API key to save (omit for interactive prompt)', required: false}),
   }
 
-  static description = `Configure your DocuTray API key for authentication. When called without arguments, prompts interactively for the key (the only interactive command in this CLI). You can also pass the key directly as an argument for non-interactive use. Credentials are stored in ~/.config/docutray/config.json with restricted file permissions.`
+  static description = `Configure your DocuTray API key for authentication. When called without arguments, prompts to choose between pasting an existing API key or authenticating via OAuth2 in the browser. OAuth2 login opens your browser, lets you select an organization, and automatically generates an API key. Credentials are stored in ~/.config/docutray/config.json with restricted file permissions.`
 
   static examples = [
-    {command: '<%= config.bin %> login', description: 'Interactive login \u2014 prompts for your API key'},
+    {command: '<%= config.bin %> login', description: 'Interactive login — choose API key or OAuth2 browser login'},
     {command: '<%= config.bin %> login dt_live_abc123', description: 'Non-interactive login with API key as argument'},
-    {command: '<%= config.bin %> login --base-url https://staging.docutray.com', description: 'Login with a custom API base URL (e.g. staging)'},
-    {command: 'DOCUTRAY_API_KEY=dt_live_abc123 docutray status', description: 'Alternative: use env var instead of login (recommended for CI/CD)'},
+    {command: '<%= config.bin %> login --api-key dt_live_abc123', description: 'Non-interactive login with API key flag'},
+    {command: '<%= config.bin %> login --base-url https://staging.docutray.com', description: 'Login with a custom API base URL'},
+    {command: 'DOCUTRAY_API_KEY=dt_live_abc123 docutray status', description: 'Alternative: use env var instead of login'},
   ]
 
   static flags = {
+    'api-key': Flags.string({description: 'API key for non-interactive login'}),
     'base-url': Flags.string({description: 'Custom base URL for the DocuTray API (default: https://app.docutray.com)'}),
     json: Flags.boolean({default: false, description: 'Output as JSON (default when piped)'}),
   }
@@ -29,60 +40,161 @@ export default class Login extends BaseCommand {
     setForceJson(flags.json)
 
     try {
-      let apiKey = args['api-key']
-      if (!apiKey) {
-        apiKey = await new Promise<string>((resolve) => {
-          process.stderr.write('Enter your DocuTray API key: ')
-          const rl = readline.createInterface({input: process.stdin, terminal: false})
-          if (process.stdin.isTTY) {
-            process.stdin.setRawMode(true)
-          }
-
-          let input = ''
-          process.stdin.resume()
-          process.stdin.on('data', (data: Buffer) => {
-            const char = data.toString()
-            if (char === '\n' || char === '\r') {
-              if (process.stdin.isTTY) {
-                process.stdin.setRawMode(false)
-              }
-
-              process.stderr.write('\n')
-              rl.close()
-              resolve(input)
-            } else if (char === '\u007F' || char === '\b') {
-              input = input.slice(0, -1)
-            } else {
-              input += char
-            }
-          })
-        })
-      }
-
-      if (!apiKey?.trim()) {
-        outputError(new Error('API key cannot be empty'))
-        this.exit(1)
-      }
-
       const config = readConfig()
-      config.apiKey = apiKey.trim()
       if (flags['base-url']) {
         config.baseUrl = flags['base-url']
       }
 
-      writeConfig(config)
+      // Determine API key from arg or flag (non-interactive paths)
+      const directApiKey = args['api-key'] || flags['api-key']
 
-      const data = {
-        message: 'Login successful',
-        apiKey: maskApiKey(config.apiKey),
-        configPath: getConfigPath(),
-        ...(config.baseUrl && {baseUrl: config.baseUrl}),
+      if (directApiKey) {
+        await this.loginWithApiKey(directApiKey.trim(), config)
+        return
       }
 
-      outputSuccess(data, `Login successful (${maskApiKey(config.apiKey)})`)
+      // Interactive: ask user if they have an API key
+      if (!isStderrInteractive()) {
+        outputError(new Error('Non-interactive mode requires --api-key flag or api-key argument'))
+        this.exit(1)
+        return
+      }
+
+      const hasKey = await this.promptYesNo('Do you already have an API key? (y/N): ')
+
+      if (hasKey) {
+        const apiKey = await this.promptHidden('Enter your DocuTray API key: ')
+        if (!apiKey?.trim()) {
+          outputError(new Error('API key cannot be empty'))
+          this.exit(1)
+          return
+        }
+
+        await this.loginWithApiKey(apiKey.trim(), config)
+      } else {
+        await this.loginWithOAuth(config)
+      }
     } catch (error) {
       outputError(error)
       this.exit(1)
     }
+  }
+
+  private async loginWithApiKey(apiKey: string, config: Config): Promise<void> {
+    config.apiKey = apiKey
+    writeConfig(config)
+
+    const data = {
+      message: 'Login successful',
+      apiKey: maskApiKey(apiKey),
+      configPath: getConfigPath(),
+      ...(config.baseUrl ? {baseUrl: config.baseUrl} : {}),
+    }
+
+    outputSuccess(data, `Login successful (${maskApiKey(apiKey)})`)
+  }
+
+  private async loginWithOAuth(config: Config): Promise<void> {
+    const {codeChallenge, codeVerifier} = generatePKCE()
+    const state = crypto.randomUUID()
+
+    const {close, port, waitForCallback} = await startCallbackServer()
+
+    try {
+      const authorizeUrl = buildAuthorizeUrl(port, state, codeChallenge)
+
+      process.stderr.write('Opening browser for authentication...\n')
+      process.stderr.write(`If the browser does not open, visit:\n${authorizeUrl}\n\n`)
+
+      // Dynamic import for ESM-only 'open' package
+      const {default: open} = await import('open')
+      await open(authorizeUrl)
+
+      process.stderr.write('Waiting for authentication (timeout: 120s)...\n')
+
+      const result = await waitForCallback()
+
+      // Validate state to prevent CSRF
+      if (result.state !== state) {
+        throw new Error('State parameter mismatch — possible CSRF attack. Please try again.')
+      }
+
+      const redirectUri = `http://localhost:${port}`
+
+      // Exchange authorization code for access token
+      process.stderr.write('Exchanging authorization code...\n')
+      const tokenResponse = await exchangeCodeForToken(result.code, codeVerifier, redirectUri)
+
+      // Extract organization ID from scope
+      const orgId = extractOrgFromScope(tokenResponse.scope || '')
+      if (!orgId) {
+        throw new Error('No organization was selected during authentication. Please try again and select an organization.')
+      }
+
+      // Create API key from OAuth token
+      process.stderr.write('Creating API key...\n')
+      const apiKeyResponse = await createApiKeyFromToken(tokenResponse.access_token, orgId)
+
+      // Save to config
+      config.apiKey = apiKeyResponse.apiKey
+      config.organizationId = apiKeyResponse.organizationId
+      config.organizationName = apiKeyResponse.organizationName
+      writeConfig(config)
+
+      const data = {
+        message: 'Login successful',
+        apiKey: maskApiKey(apiKeyResponse.apiKey),
+        organizationId: apiKeyResponse.organizationId,
+        organizationName: apiKeyResponse.organizationName,
+        configPath: getConfigPath(),
+      }
+
+      outputSuccess(
+        data,
+        `Login successful — ${apiKeyResponse.organizationName} (${maskApiKey(apiKeyResponse.apiKey)})`,
+      )
+    } finally {
+      close()
+    }
+  }
+
+  private promptHidden(prompt: string): Promise<string> {
+    return new Promise<string>((resolve) => {
+      process.stderr.write(prompt)
+      const rl = readline.createInterface({input: process.stdin, terminal: false})
+      if (process.stdin.isTTY) {
+        process.stdin.setRawMode(true)
+      }
+
+      let input = ''
+      process.stdin.resume()
+      process.stdin.on('data', (data: Buffer) => {
+        const char = data.toString()
+        if (char === '\n' || char === '\r') {
+          if (process.stdin.isTTY) {
+            process.stdin.setRawMode(false)
+          }
+
+          process.stderr.write('\n')
+          rl.close()
+          resolve(input)
+        } else if (char === '\u007F' || char === '\b') {
+          input = input.slice(0, -1)
+        } else {
+          input += char
+        }
+      })
+    })
+  }
+
+  private promptYesNo(prompt: string): Promise<boolean> {
+    return new Promise<boolean>((resolve) => {
+      process.stderr.write(prompt)
+      const rl = readline.createInterface({input: process.stdin, terminal: false})
+      rl.on('line', (line: string) => {
+        rl.close()
+        resolve(line.trim().toLowerCase() === 'y')
+      })
+    })
   }
 }

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -82,6 +82,8 @@ export default class Login extends BaseCommand {
 
   private async loginWithApiKey(apiKey: string, config: Config): Promise<void> {
     config.apiKey = apiKey
+    delete config.organizationId
+    delete config.organizationName
     writeConfig(config)
 
     const data = {
@@ -101,7 +103,7 @@ export default class Login extends BaseCommand {
     const {close, port, waitForCallback} = await startCallbackServer()
 
     try {
-      const authorizeUrl = buildAuthorizeUrl(port, state, codeChallenge)
+      const authorizeUrl = buildAuthorizeUrl(port, state, codeChallenge, config.baseUrl)
 
       process.stderr.write('Opening browser for authentication...\n')
       process.stderr.write(`If the browser does not open, visit:\n${authorizeUrl}\n\n`)
@@ -119,11 +121,11 @@ export default class Login extends BaseCommand {
         throw new Error('State parameter mismatch — possible CSRF attack. Please try again.')
       }
 
-      const redirectUri = `http://localhost:${port}`
+      const redirectUri = `http://127.0.0.1:${port}`
 
       // Exchange authorization code for access token
       process.stderr.write('Exchanging authorization code...\n')
-      const tokenResponse = await exchangeCodeForToken(result.code, codeVerifier, redirectUri)
+      const tokenResponse = await exchangeCodeForToken(result.code, codeVerifier, redirectUri, config.baseUrl)
 
       // Extract organization ID from scope
       const orgId = extractOrgFromScope(tokenResponse.scope || '')
@@ -133,7 +135,7 @@ export default class Login extends BaseCommand {
 
       // Create API key from OAuth token
       process.stderr.write('Creating API key...\n')
-      const apiKeyResponse = await createApiKeyFromToken(tokenResponse.access_token, orgId)
+      const apiKeyResponse = await createApiKeyFromToken(tokenResponse.access_token, orgId, config.baseUrl)
 
       // Save to config
       config.apiKey = apiKeyResponse.apiKey
@@ -167,14 +169,15 @@ export default class Login extends BaseCommand {
       }
 
       let input = ''
-      process.stdin.resume()
-      process.stdin.on('data', (data: Buffer) => {
+      const onData = (data: Buffer) => {
         const char = data.toString()
         if (char === '\n' || char === '\r') {
           if (process.stdin.isTTY) {
             process.stdin.setRawMode(false)
           }
 
+          process.stdin.removeListener('data', onData)
+          process.stdin.pause()
           process.stderr.write('\n')
           rl.close()
           resolve(input)
@@ -183,7 +186,10 @@ export default class Login extends BaseCommand {
         } else {
           input += char
         }
-      })
+      }
+
+      process.stdin.resume()
+      process.stdin.on('data', onData)
     })
   }
 

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -28,7 +28,7 @@ export default class Status extends BaseCommand {
       const source = process.env.DOCUTRAY_API_KEY ? 'environment' : config.apiKey ? 'config' : 'none'
       const authenticated = Boolean(apiKey)
 
-      const data = {
+      const data: Record<string, unknown> = {
         authenticated,
         apiKey: apiKey ? maskApiKey(apiKey) : null,
         source,
@@ -36,13 +36,21 @@ export default class Status extends BaseCommand {
         configPath: getConfigPath(),
       }
 
-      outputKeyValue(data, [
+      const entries = [
         {key: 'Authenticated', value: authenticated ? 'yes' : 'no', icon: authenticated ? '\u2713' : '\u2717'},
         {key: 'API Key', value: apiKey ? maskApiKey(apiKey) : 'none'},
         {key: 'Source', value: source === 'environment' ? 'environment variable' : source === 'config' ? 'config file' : 'none'},
-        {key: 'Base URL', value: data.baseUrl},
+        {key: 'Base URL', value: data.baseUrl as string},
         {key: 'Config', value: getConfigPath()},
-      ])
+      ]
+
+      if (config.organizationId) {
+        data.organizationId = config.organizationId
+        data.organizationName = config.organizationName
+        entries.splice(3, 0, {key: 'Organization', value: `${config.organizationName || ''} (${config.organizationId})`})
+      }
+
+      outputKeyValue(data, entries)
     } catch (error) {
       outputError(error)
       this.exit(1)

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,9 +5,11 @@ import {join} from 'node:path'
 const CONFIG_DIR = join(homedir(), '.config', 'docutray')
 const CONFIG_FILE = join(CONFIG_DIR, 'config.json')
 
-interface Config {
+export interface Config {
   apiKey?: string
   baseUrl?: string
+  organizationId?: string
+  organizationName?: string
 }
 
 export function getConfigDir(): string {

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -1,0 +1,168 @@
+import * as crypto from 'node:crypto'
+import * as http from 'node:http'
+
+import {getBaseUrl} from './config.js'
+
+const CLIENT_ID = 'docutray-cli'
+const DEFAULT_BASE_URL = 'https://app.docutray.com'
+const OAUTH_TIMEOUT_MS = 120_000
+
+export interface PKCEChallenge {
+  codeChallenge: string
+  codeVerifier: string
+}
+
+export interface CallbackResult {
+  code: string
+  state: string
+}
+
+export interface TokenResponse {
+  access_token: string
+  expires_in: number
+  refresh_token?: string
+  scope?: string
+  token_type: string
+}
+
+export interface ApiKeyResponse {
+  apiKey: string
+  organizationId: string
+  organizationName: string
+}
+
+export function generatePKCE(): PKCEChallenge {
+  const codeVerifier = crypto.randomBytes(32).toString('base64url')
+  const codeChallenge = crypto
+    .createHash('sha256')
+    .update(codeVerifier)
+    .digest('base64url')
+  return {codeChallenge, codeVerifier}
+}
+
+export function buildAuthorizeUrl(port: number, state: string, codeChallenge: string): string {
+  const baseUrl = getBaseUrl() || DEFAULT_BASE_URL
+  const params = new URLSearchParams({
+    client_id: CLIENT_ID,
+    code_challenge: codeChallenge,
+    code_challenge_method: 'S256',
+    redirect_uri: `http://localhost:${port}`,
+    response_type: 'code',
+    scope: 'openid',
+    state,
+  })
+  return `${baseUrl}/api/auth/oauth2/authorize?${params.toString()}`
+}
+
+export async function startCallbackServer(): Promise<{
+  port: number
+  close: () => void
+  waitForCallback: (timeout?: number) => Promise<CallbackResult>
+}> {
+  let resolveCallback: (result: CallbackResult) => void
+  let rejectCallback: (error: Error) => void
+
+  const callbackPromise = new Promise<CallbackResult>((resolve, reject) => {
+    resolveCallback = resolve
+    rejectCallback = reject
+  })
+
+  const server = http.createServer((req, res) => {
+    const url = new URL(req.url || '/', `http://localhost`)
+    const code = url.searchParams.get('code')
+    const state = url.searchParams.get('state')
+    const error = url.searchParams.get('error')
+
+    if (error) {
+      const description = url.searchParams.get('error_description') || error
+      res.writeHead(200, {'Content-Type': 'text/html'})
+      res.end('<html><body><h1>Authentication failed</h1><p>You can close this window.</p></body></html>')
+      rejectCallback(new Error(`OAuth error: ${description}`))
+      return
+    }
+
+    if (!code || !state) {
+      res.writeHead(400, {'Content-Type': 'text/html'})
+      res.end('<html><body><h1>Invalid callback</h1><p>Missing code or state parameter.</p></body></html>')
+      return
+    }
+
+    res.writeHead(200, {'Content-Type': 'text/html'})
+    res.end('<html><body><h1>Authentication successful!</h1><p>You can close this window and return to the terminal.</p></body></html>')
+    resolveCallback({code, state})
+  })
+
+  const port = await new Promise<number>((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address()
+      resolve(typeof address === 'object' && address ? address.port : 0)
+    })
+  })
+
+  return {
+    close: () => server.close(),
+    port,
+    waitForCallback: (timeout = OAUTH_TIMEOUT_MS) => {
+      const timer = setTimeout(() => {
+        rejectCallback(new Error(`Authentication timed out after ${timeout / 1000}s. Please try again.`))
+      }, timeout)
+
+      return callbackPromise.finally(() => {
+        clearTimeout(timer)
+      })
+    },
+  }
+}
+
+export async function exchangeCodeForToken(
+  code: string,
+  codeVerifier: string,
+  redirectUri: string,
+): Promise<TokenResponse> {
+  const baseUrl = getBaseUrl() || DEFAULT_BASE_URL
+  const response = await fetch(`${baseUrl}/api/auth/oauth2/token`, {
+    body: new URLSearchParams({
+      client_id: CLIENT_ID,
+      code,
+      code_verifier: codeVerifier,
+      grant_type: 'authorization_code',
+      redirect_uri: redirectUri,
+    }).toString(),
+    headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+    method: 'POST',
+  })
+
+  if (!response.ok) {
+    const text = await response.text()
+    throw new Error(`Token exchange failed (${response.status}): ${text}`)
+  }
+
+  return response.json() as Promise<TokenResponse>
+}
+
+export function extractOrgFromScope(scope: string): string | undefined {
+  const match = scope.match(/org:(\S+)/)
+  return match?.[1]
+}
+
+export async function createApiKeyFromToken(
+  accessToken: string,
+  organizationId: string,
+): Promise<ApiKeyResponse> {
+  const baseUrl = getBaseUrl() || DEFAULT_BASE_URL
+  const response = await fetch(`${baseUrl}/api/auth/oauth/create-api-key`, {
+    body: JSON.stringify({organizationId}),
+    headers: {
+      'Authorization': `Bearer ${accessToken}`,
+      'Content-Type': 'application/json',
+    },
+    method: 'POST',
+  })
+
+  if (!response.ok) {
+    const text = await response.text()
+    throw new Error(`API key creation failed (${response.status}): ${text}`)
+  }
+
+  return response.json() as Promise<ApiKeyResponse>
+}

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -40,18 +40,18 @@ export function generatePKCE(): PKCEChallenge {
   return {codeChallenge, codeVerifier}
 }
 
-export function buildAuthorizeUrl(port: number, state: string, codeChallenge: string): string {
-  const baseUrl = getBaseUrl() || DEFAULT_BASE_URL
+export function buildAuthorizeUrl(port: number, state: string, codeChallenge: string, baseUrl?: string): string {
+  const resolvedBaseUrl = baseUrl || getBaseUrl() || DEFAULT_BASE_URL
   const params = new URLSearchParams({
     client_id: CLIENT_ID,
     code_challenge: codeChallenge,
     code_challenge_method: 'S256',
-    redirect_uri: `http://localhost:${port}`,
+    redirect_uri: `http://127.0.0.1:${port}`,
     response_type: 'code',
     scope: 'openid',
     state,
   })
-  return `${baseUrl}/api/auth/oauth2/authorize?${params.toString()}`
+  return `${resolvedBaseUrl}/api/auth/oauth2/authorize?${params.toString()}`
 }
 
 export async function startCallbackServer(): Promise<{
@@ -82,8 +82,9 @@ export async function startCallbackServer(): Promise<{
     }
 
     if (!code || !state) {
-      res.writeHead(400, {'Content-Type': 'text/html'})
-      res.end('<html><body><h1>Invalid callback</h1><p>Missing code or state parameter.</p></body></html>')
+      // Ignore requests without OAuth params (e.g. browser favicon.ico)
+      res.writeHead(404)
+      res.end()
       return
     }
 
@@ -118,9 +119,10 @@ export async function exchangeCodeForToken(
   code: string,
   codeVerifier: string,
   redirectUri: string,
+  baseUrl?: string,
 ): Promise<TokenResponse> {
-  const baseUrl = getBaseUrl() || DEFAULT_BASE_URL
-  const response = await fetch(`${baseUrl}/api/auth/oauth2/token`, {
+  const resolvedBaseUrl = baseUrl || getBaseUrl() || DEFAULT_BASE_URL
+  const response = await fetch(`${resolvedBaseUrl}/api/auth/oauth2/token`, {
     body: new URLSearchParams({
       client_id: CLIENT_ID,
       code,
@@ -148,9 +150,10 @@ export function extractOrgFromScope(scope: string): string | undefined {
 export async function createApiKeyFromToken(
   accessToken: string,
   organizationId: string,
+  baseUrl?: string,
 ): Promise<ApiKeyResponse> {
-  const baseUrl = getBaseUrl() || DEFAULT_BASE_URL
-  const response = await fetch(`${baseUrl}/api/auth/oauth/create-api-key`, {
+  const resolvedBaseUrl = baseUrl || getBaseUrl() || DEFAULT_BASE_URL
+  const response = await fetch(`${resolvedBaseUrl}/api/auth/oauth/create-api-key`, {
     body: JSON.stringify({organizationId}),
     headers: {
       'Authorization': `Bearer ${accessToken}`,

--- a/test/__snapshots__/help.test.ts.snap
+++ b/test/__snapshots__/help.test.ts.snap
@@ -114,28 +114,31 @@ DOCUMENTATION
 `;
 
 exports[`help output > login --help output matches snapshot 1`] = `
-"Configure your DocuTray API key for authentication. When called without arguments, prompts interactively for the key (the only interactive command in this CLI). You can also pass the key directly as an argument for non-interactive use. Credentials are stored in ~/.config/docutray/config.json with restricted file permissions.
+"Configure your DocuTray API key for authentication. When called without arguments, prompts to choose between pasting an existing API key or authenticating via OAuth2 in the browser. OAuth2 login opens your browser, lets you select an organization, and automatically generates an API key. Credentials are stored in ~/.config/docutray/config.json with restricted file permissions.
 
 USAGE
-  $ docutray login [API-KEY] [--base-url <value>] [--json]
+  $ docutray login [API-KEY] [--api-key <value>] [--base-url
+    <value>] [--json]
 
 ARGUMENTS
   [API-KEY]  API key to save (omit for interactive prompt)
 
 FLAGS
+  --api-key=<value>   API key for non-interactive login
   --base-url=<value>  Custom base URL for the DocuTray API (default:
                       https://app.docutray.com)
   --json              Output as JSON (default when piped)
 
 DESCRIPTION
   Configure your DocuTray API key for authentication. When called without
-  arguments, prompts interactively for the key (the only interactive command in
-  this CLI). You can also pass the key directly as an argument for
-  non-interactive use. Credentials are stored in ~/.config/docutray/config.json
-  with restricted file permissions.
+  arguments, prompts to choose between pasting an existing API key or
+  authenticating via OAuth2 in the browser. OAuth2 login opens your browser,
+  lets you select an organization, and automatically generates an API key.
+  Credentials are stored in ~/.config/docutray/config.json with restricted file
+  permissions.
 
 EXAMPLES
-  Interactive login — prompts for your API key
+  Interactive login — choose API key or OAuth2 browser login
 
     $ docutray login
 
@@ -143,11 +146,15 @@ EXAMPLES
 
     $ docutray login dt_live_abc123
 
-  Login with a custom API base URL (e.g. staging)
+  Non-interactive login with API key flag
+
+    $ docutray login --api-key dt_live_abc123
+
+  Login with a custom API base URL
 
     $ docutray login --base-url https://staging.docutray.com
 
-  Alternative: use env var instead of login (recommended for CI/CD)
+  Alternative: use env var instead of login
 
     DOCUTRAY_API_KEY=dt_live_abc123 docutray status
 

--- a/test/commands/login.test.ts
+++ b/test/commands/login.test.ts
@@ -1,0 +1,238 @@
+import {describe, expect, it, vi, beforeEach} from 'vitest'
+
+vi.mock('node:crypto', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:crypto')>()
+  return {
+    ...actual,
+    randomUUID: vi.fn(() => 'fixed-state-123'),
+  }
+})
+
+vi.mock('../../src/config.js', () => ({
+  getConfigPath: vi.fn(() => '/home/user/.config/docutray/config.json'),
+  maskApiKey: vi.fn((key: string) => key.slice(0, 4) + '****' + key.slice(-4)),
+  readConfig: vi.fn(() => ({})),
+  writeConfig: vi.fn(),
+  getBaseUrl: vi.fn(() => undefined),
+}))
+
+vi.mock('../../src/oauth.js', () => ({
+  buildAuthorizeUrl: vi.fn(() => 'https://app.docutray.com/api/auth/oauth2/authorize?test=1'),
+  createApiKeyFromToken: vi.fn(),
+  exchangeCodeForToken: vi.fn(),
+  extractOrgFromScope: vi.fn(),
+  generatePKCE: vi.fn(() => ({codeVerifier: 'test-verifier', codeChallenge: 'test-challenge'})),
+  startCallbackServer: vi.fn(),
+}))
+
+vi.mock('open', () => ({
+  default: vi.fn(),
+}))
+
+vi.mock('node:readline', () => {
+  let nextAnswer = ''
+  return {
+    createInterface: vi.fn(() => ({
+      close: vi.fn(),
+      on: vi.fn((event: string, listener: Function) => {
+        if (event === 'line') {
+          setTimeout(() => listener(nextAnswer), 5)
+        }
+        return {close: vi.fn(), on: vi.fn()}
+      }),
+    })),
+    __setNextAnswer: (answer: string) => { nextAnswer = answer },
+  }
+})
+
+import {writeConfig, readConfig} from '../../src/config.js'
+import {
+  createApiKeyFromToken,
+  exchangeCodeForToken,
+  extractOrgFromScope,
+  startCallbackServer,
+} from '../../src/oauth.js'
+import Login from '../../src/commands/login.js'
+
+const mockWriteConfig = vi.mocked(writeConfig)
+const mockStartCallbackServer = vi.mocked(startCallbackServer)
+const mockExchangeCodeForToken = vi.mocked(exchangeCodeForToken)
+const mockExtractOrgFromScope = vi.mocked(extractOrgFromScope)
+const mockCreateApiKeyFromToken = vi.mocked(createApiKeyFromToken)
+
+describe('login with --api-key flag', () => {
+  let stdoutSpy: ReturnType<typeof vi.spyOn>
+  let stderrSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+    stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+  })
+
+  it('saves API key from --api-key flag', async () => {
+    await Login.run(['--api-key', 'dt_live_abc12345'])
+    expect(mockWriteConfig).toHaveBeenCalledWith(
+      expect.objectContaining({apiKey: 'dt_live_abc12345'}),
+    )
+  })
+
+  it('saves API key from positional argument', async () => {
+    await Login.run(['dt_live_abc12345'])
+    expect(mockWriteConfig).toHaveBeenCalledWith(
+      expect.objectContaining({apiKey: 'dt_live_abc12345'}),
+    )
+  })
+
+  it('outputs success with masked key', async () => {
+    await Login.run(['dt_live_abc12345', '--json'])
+    const output = stdoutSpy.mock.calls.map(c => c[0] as string).join('')
+    const parsed = JSON.parse(output)
+    expect(parsed.message).toBe('Login successful')
+    expect(parsed.apiKey).toContain('****')
+  })
+
+  it('saves base-url when provided', async () => {
+    await Login.run(['--api-key', 'dt_live_abc12345', '--base-url', 'https://staging.docutray.com'])
+    expect(mockWriteConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKey: 'dt_live_abc12345',
+        baseUrl: 'https://staging.docutray.com',
+      }),
+    )
+  })
+})
+
+describe('login with OAuth2 flow', () => {
+  let stdoutSpy: ReturnType<typeof vi.spyOn>
+  let stderrSpy: ReturnType<typeof vi.spyOn>
+  let stdinListeners: Map<string, Function>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+    stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    stdinListeners = new Map()
+  })
+
+  function setupOAuthMocks() {
+    const closeFn = vi.fn()
+    mockStartCallbackServer.mockResolvedValue({
+      port: 9999,
+      close: closeFn,
+      waitForCallback: vi.fn().mockResolvedValue({code: 'auth-code', state: 'fixed-state-123'}),
+    })
+
+    mockExchangeCodeForToken.mockResolvedValue({
+      access_token: 'oauth-token-123',
+      token_type: 'bearer',
+      expires_in: 3600,
+      scope: 'openid org:org_abc',
+    })
+
+    mockExtractOrgFromScope.mockReturnValue('org_abc')
+
+    mockCreateApiKeyFromToken.mockResolvedValue({
+      apiKey: 'dt_live_newkey123',
+      organizationId: 'org_abc',
+      organizationName: 'My Organization',
+    })
+
+    return {closeFn}
+  }
+
+  it('errors in non-interactive mode without --api-key', async () => {
+    const originalIsTTY = process.stderr.isTTY
+    process.stderr.isTTY = false
+    const exitSpy = vi.spyOn(Login.prototype, 'exit').mockImplementation(() => {
+      throw new Error('EXIT')
+    })
+
+    try {
+      await expect(Login.run(['--json'])).rejects.toThrow('EXIT')
+      expect(stderrSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Non-interactive mode requires --api-key'),
+      )
+    } finally {
+      process.stderr.isTTY = originalIsTTY
+      exitSpy.mockRestore()
+    }
+  })
+
+  it('calls exchangeCodeForToken with correct parameters', async () => {
+    setupOAuthMocks()
+
+    // Mock waitForCallback to return matching state
+    const waitFn = vi.fn()
+    mockStartCallbackServer.mockResolvedValue({
+      port: 9999,
+      close: vi.fn(),
+      waitForCallback: waitFn,
+    })
+
+    waitFn.mockResolvedValue({code: 'auth-code', state: 'fixed-state-123'})
+
+    // Simulate interactive TTY + user pressing 'n' for "no API key"
+    const originalIsTTY = process.stderr.isTTY
+    process.stderr.isTTY = true
+
+    // Mock readline - user answers 'n' to "Do you have API key?"
+    const originalCreateInterface = (await import('node:readline')).createInterface
+    const {createInterface} = await import('node:readline')
+
+    const exitSpy = vi.spyOn(Login.prototype, 'exit').mockImplementation(() => {
+      throw new Error('EXIT')
+    })
+
+    try {
+      // This will fail due to state mismatch, which is expected
+      // The important thing is that the OAuth flow was initiated
+      await expect(Login.run(['--api-key', 'dt_live_test123'])).resolves.not.toThrow()
+      // With --api-key flag, it skips OAuth entirely
+      expect(mockWriteConfig).toHaveBeenCalledWith(
+        expect.objectContaining({apiKey: 'dt_live_test123'}),
+      )
+    } finally {
+      process.stderr.isTTY = originalIsTTY
+      exitSpy.mockRestore()
+    }
+  })
+
+  it('executes full OAuth flow and saves org info to config', async () => {
+    const {closeFn} = setupOAuthMocks()
+
+    mockStartCallbackServer.mockResolvedValue({
+      port: 9999,
+      close: closeFn,
+      waitForCallback: vi.fn().mockResolvedValue({code: 'auth-code', state: 'fixed-state-123'}),
+    })
+
+    const originalIsTTY = process.stderr.isTTY
+    process.stderr.isTTY = true
+
+    // Set readline mock to answer 'n' (no API key → OAuth flow)
+    const {__setNextAnswer} = await import('node:readline') as any
+    __setNextAnswer('n')
+
+    try {
+      await Login.run([])
+
+      expect(mockExchangeCodeForToken).toHaveBeenCalledWith(
+        'auth-code',
+        'test-verifier',
+        'http://localhost:9999',
+      )
+      expect(mockCreateApiKeyFromToken).toHaveBeenCalledWith('oauth-token-123', 'org_abc')
+      expect(mockWriteConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          apiKey: 'dt_live_newkey123',
+          organizationId: 'org_abc',
+          organizationName: 'My Organization',
+        }),
+      )
+      expect(closeFn).toHaveBeenCalled()
+    } finally {
+      process.stderr.isTTY = originalIsTTY
+    }
+  })
+})

--- a/test/commands/login.test.ts
+++ b/test/commands/login.test.ts
@@ -106,13 +106,10 @@ describe('login with --api-key flag', () => {
 describe('login with OAuth2 flow', () => {
   let stdoutSpy: ReturnType<typeof vi.spyOn>
   let stderrSpy: ReturnType<typeof vi.spyOn>
-  let stdinListeners: Map<string, Function>
-
   beforeEach(() => {
     vi.clearAllMocks()
     stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
     stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
-    stdinListeners = new Map()
   })
 
   function setupOAuthMocks() {
@@ -159,43 +156,15 @@ describe('login with OAuth2 flow', () => {
     }
   })
 
-  it('calls exchangeCodeForToken with correct parameters', async () => {
+  it('skips OAuth flow when --api-key flag is provided', async () => {
     setupOAuthMocks()
 
-    // Mock waitForCallback to return matching state
-    const waitFn = vi.fn()
-    mockStartCallbackServer.mockResolvedValue({
-      port: 9999,
-      close: vi.fn(),
-      waitForCallback: waitFn,
-    })
-
-    waitFn.mockResolvedValue({code: 'auth-code', state: 'fixed-state-123'})
-
-    // Simulate interactive TTY + user pressing 'n' for "no API key"
-    const originalIsTTY = process.stderr.isTTY
-    process.stderr.isTTY = true
-
-    // Mock readline - user answers 'n' to "Do you have API key?"
-    const originalCreateInterface = (await import('node:readline')).createInterface
-    const {createInterface} = await import('node:readline')
-
-    const exitSpy = vi.spyOn(Login.prototype, 'exit').mockImplementation(() => {
-      throw new Error('EXIT')
-    })
-
-    try {
-      // This will fail due to state mismatch, which is expected
-      // The important thing is that the OAuth flow was initiated
-      await expect(Login.run(['--api-key', 'dt_live_test123'])).resolves.not.toThrow()
-      // With --api-key flag, it skips OAuth entirely
-      expect(mockWriteConfig).toHaveBeenCalledWith(
-        expect.objectContaining({apiKey: 'dt_live_test123'}),
-      )
-    } finally {
-      process.stderr.isTTY = originalIsTTY
-      exitSpy.mockRestore()
-    }
+    await Login.run(['--api-key', 'dt_live_test123'])
+    // With --api-key flag, it goes directly to loginWithApiKey
+    expect(mockWriteConfig).toHaveBeenCalledWith(
+      expect.objectContaining({apiKey: 'dt_live_test123'}),
+    )
+    expect(mockStartCallbackServer).not.toHaveBeenCalled()
   })
 
   it('executes full OAuth flow and saves org info to config', async () => {

--- a/test/commands/login.test.ts
+++ b/test/commands/login.test.ts
@@ -189,9 +189,10 @@ describe('login with OAuth2 flow', () => {
       expect(mockExchangeCodeForToken).toHaveBeenCalledWith(
         'auth-code',
         'test-verifier',
-        'http://localhost:9999',
+        'http://127.0.0.1:9999',
+        undefined,
       )
-      expect(mockCreateApiKeyFromToken).toHaveBeenCalledWith('oauth-token-123', 'org_abc')
+      expect(mockCreateApiKeyFromToken).toHaveBeenCalledWith('oauth-token-123', 'org_abc', undefined)
       expect(mockWriteConfig).toHaveBeenCalledWith(
         expect.objectContaining({
           apiKey: 'dt_live_newkey123',

--- a/test/oauth.test.ts
+++ b/test/oauth.test.ts
@@ -1,0 +1,111 @@
+import {describe, expect, it, vi, beforeEach, afterEach} from 'vitest'
+import * as http from 'node:http'
+
+vi.mock('../src/config.js', () => ({
+  getBaseUrl: vi.fn(() => 'https://app.docutray.com'),
+}))
+
+import {
+  buildAuthorizeUrl,
+  extractOrgFromScope,
+  generatePKCE,
+  startCallbackServer,
+} from '../src/oauth.js'
+
+describe('generatePKCE', () => {
+  it('returns codeVerifier and codeChallenge', () => {
+    const {codeVerifier, codeChallenge} = generatePKCE()
+    expect(codeVerifier).toBeTruthy()
+    expect(codeChallenge).toBeTruthy()
+    expect(codeVerifier).not.toBe(codeChallenge)
+  })
+
+  it('generates different values each call', () => {
+    const a = generatePKCE()
+    const b = generatePKCE()
+    expect(a.codeVerifier).not.toBe(b.codeVerifier)
+  })
+
+  it('codeVerifier is base64url encoded', () => {
+    const {codeVerifier} = generatePKCE()
+    expect(codeVerifier).toMatch(/^[A-Za-z0-9_-]+$/)
+  })
+
+  it('codeChallenge is base64url encoded', () => {
+    const {codeChallenge} = generatePKCE()
+    expect(codeChallenge).toMatch(/^[A-Za-z0-9_-]+$/)
+  })
+})
+
+describe('buildAuthorizeUrl', () => {
+  it('constructs correct URL with all params', () => {
+    const url = buildAuthorizeUrl(3456, 'test-state', 'test-challenge')
+    const parsed = new URL(url)
+    expect(parsed.origin).toBe('https://app.docutray.com')
+    expect(parsed.pathname).toBe('/api/auth/oauth2/authorize')
+    expect(parsed.searchParams.get('client_id')).toBe('docutray-cli')
+    expect(parsed.searchParams.get('response_type')).toBe('code')
+    expect(parsed.searchParams.get('redirect_uri')).toBe('http://localhost:3456')
+    expect(parsed.searchParams.get('state')).toBe('test-state')
+    expect(parsed.searchParams.get('code_challenge')).toBe('test-challenge')
+    expect(parsed.searchParams.get('code_challenge_method')).toBe('S256')
+    expect(parsed.searchParams.get('scope')).toBe('openid')
+  })
+})
+
+describe('extractOrgFromScope', () => {
+  it('extracts org id from scope string', () => {
+    expect(extractOrgFromScope('openid org:org_123')).toBe('org_123')
+  })
+
+  it('returns undefined when no org in scope', () => {
+    expect(extractOrgFromScope('openid profile')).toBeUndefined()
+  })
+
+  it('returns undefined for empty scope', () => {
+    expect(extractOrgFromScope('')).toBeUndefined()
+  })
+
+  it('extracts first org from multiple scopes', () => {
+    expect(extractOrgFromScope('openid org:abc123 email')).toBe('abc123')
+  })
+})
+
+describe('startCallbackServer', () => {
+  it('starts server on a random port', async () => {
+    const {port, close} = await startCallbackServer()
+    expect(port).toBeGreaterThan(0)
+    close()
+  })
+
+  it('resolves with code and state on valid callback', async () => {
+    const {port, close, waitForCallback} = await startCallbackServer()
+    const promise = waitForCallback()
+
+    // Simulate browser callback
+    await fetch(`http://127.0.0.1:${port}/?code=test-code&state=test-state`)
+
+    const result = await promise
+    expect(result.code).toBe('test-code')
+    expect(result.state).toBe('test-state')
+    close()
+  })
+
+  it('rejects on OAuth error callback', async () => {
+    const {port, close, waitForCallback} = await startCallbackServer()
+    const promise = waitForCallback()
+
+    // Start the fetch but don't await it yet - let the server process the request
+    const fetchPromise = fetch(`http://127.0.0.1:${port}/?error=access_denied&error_description=User+denied`)
+
+    await expect(promise).rejects.toThrow('OAuth error: User denied')
+    await fetchPromise
+    close()
+  })
+
+  it('rejects on timeout', async () => {
+    const {close, waitForCallback} = await startCallbackServer()
+    await expect(waitForCallback(100)).rejects.toThrow('Authentication timed out')
+    close()
+  })
+})

--- a/test/oauth.test.ts
+++ b/test/oauth.test.ts
@@ -1,5 +1,4 @@
-import {describe, expect, it, vi, beforeEach, afterEach} from 'vitest'
-import * as http from 'node:http'
+import {describe, expect, it, vi, beforeEach} from 'vitest'
 
 vi.mock('../src/config.js', () => ({
   getBaseUrl: vi.fn(() => 'https://app.docutray.com'),

--- a/test/oauth.test.ts
+++ b/test/oauth.test.ts
@@ -44,7 +44,7 @@ describe('buildAuthorizeUrl', () => {
     expect(parsed.pathname).toBe('/api/auth/oauth2/authorize')
     expect(parsed.searchParams.get('client_id')).toBe('docutray-cli')
     expect(parsed.searchParams.get('response_type')).toBe('code')
-    expect(parsed.searchParams.get('redirect_uri')).toBe('http://localhost:3456')
+    expect(parsed.searchParams.get('redirect_uri')).toBe('http://127.0.0.1:3456')
     expect(parsed.searchParams.get('state')).toBe('test-state')
     expect(parsed.searchParams.get('code_challenge')).toBe('test-challenge')
     expect(parsed.searchParams.get('code_challenge_method')).toBe('S256')


### PR DESCRIPTION
## Related Issue
Closes #26

## Summary
- Add OAuth2 authentication flow with PKCE (S256) as alternative to manual API key entry
- `docutray login` now prompts: "Do you already have an API key?" — yes → paste key, no → browser OAuth2
- New `src/oauth.ts` module: PKCE generation, local callback server, token exchange, API key creation
- `src/config.ts` extended with `organizationId` and `organizationName` fields
- `docutray status` now shows organization info when available
- New `--api-key` flag for non-interactive login (CI/CD friendly)
- 120s timeout for browser authentication flow

## Changes
| File | Change |
|---|---|
| `src/oauth.ts` | New module: PKCE, callback server, token exchange, API key creation |
| `src/commands/login.ts` | Rewritten: yes/no prompt, OAuth2 flow, `--api-key` flag |
| `src/config.ts` | Extended Config interface with org fields, exported type |
| `src/commands/status.ts` | Show organization info |
| `package.json` | Added `open` dependency |
| `test/oauth.test.ts` | 13 tests: PKCE, URL building, scope parsing, callback server |
| `test/commands/login.test.ts` | 7 tests: API key flag, positional arg, non-interactive error, OAuth flow |

## Test plan
- [x] Build passes (`npm run build`)
- [x] All 122 tests pass (`npm run test`)
- [x] OAuth module tests: PKCE generation, authorize URL, scope extraction, callback server lifecycle
- [x] Login command tests: both API key and OAuth paths, non-interactive error handling
- [x] Help snapshot updated for new description and flags
- [ ] Manual test with running DocuTray backend (pre-production)

🤖 Generated with [Claude Code](https://claude.com/claude-code)