### PR TITLE
fix: redact pageOptions from JSON output to prevent apiKey leak

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@docutray/cli",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@docutray/cli",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docutray/cli",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Official DocuTray CLI — AI-powered document processing from the command line",
   "author": "DocuTray",
   "license": "MIT",

--- a/src/commands/types/list.ts
+++ b/src/commands/types/list.ts
@@ -47,7 +47,8 @@ export default class TypesList extends BaseCommand {
       const totalPages = Math.max(1, Math.ceil(count / flags.limit))
       const footer = `Page ${flags.page} of ${totalPages} (${count} results)`
 
-      outputList(result, rows, ['code', 'name', 'public', 'draft'], footer)
+      const payload = {data: result.data, pagination: (result as unknown as {pagination?: unknown}).pagination}
+      outputList(payload, rows, ['code', 'name', 'public', 'draft'], footer)
     } catch (error) {
       outputError(error)
       this.exit(1)

--- a/src/output.ts
+++ b/src/output.ts
@@ -15,7 +15,15 @@ export function isStderrInteractive(): boolean {
 }
 
 export function outputJson(data: unknown): void {
-  process.stdout.write(JSON.stringify(data, null, 2) + '\n')
+  process.stdout.write(JSON.stringify(data, sanitizeReplacer, 2) + '\n')
+}
+
+// Strips internal SDK fields that may carry credentials (e.g. Page.pageOptions
+// from the docutray SDK leaks the apiKey). Defense-in-depth so any future
+// command that returns an SDK object with these fields stays safe.
+function sanitizeReplacer(key: string, value: unknown): unknown {
+  if (key === 'pageOptions') return undefined
+  return value
 }
 
 export function outputError(error: unknown): void {

--- a/test/commands/types/list.test.ts
+++ b/test/commands/types/list.test.ts
@@ -1,0 +1,72 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+vi.mock('../../../src/client.js', () => ({
+  createClient: vi.fn(),
+}))
+
+import {createClient} from '../../../src/client.js'
+import TypesList from '../../../src/commands/types/list.js'
+
+const mockCreateClient = vi.mocked(createClient)
+
+// Mimics the shape of the SDK's Page instance: `data` and `pagination` are
+// the public fields, `pageOptions` is an internal field that carries the
+// API client (and the apiKey). JSON.stringify will serialize `pageOptions`
+// unless the CLI strips it.
+function pageWithLeakedApiKey() {
+  return {
+    data: [
+      {codeType: 'invoice', id: 'cmnp1nxdb004s01tm5gxakfdl', isDraft: false, isPublic: true, name: 'Invoice'},
+    ],
+    pageOptions: {
+      client: {apiKey: 'dt_live_secret_should_never_be_printed', baseURL: 'https://app.docutray.com'},
+      path: '/api/document-types',
+      query: {limit: 20, page: 1},
+    },
+    pagination: {limit: 20, page: 1, total: 1},
+  }
+}
+
+function mockClient(pageData = pageWithLeakedApiKey()) {
+  const client = {
+    documentTypes: {
+      list: vi.fn().mockResolvedValue(pageData),
+    },
+  }
+  mockCreateClient.mockReturnValue(client as never)
+  return client
+}
+
+describe('types list', () => {
+  let stdoutSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+  })
+
+  it('does not leak pageOptions or apiKey when --json is set', async () => {
+    mockClient()
+
+    await TypesList.run(['--json'])
+
+    const stdoutOutput = stdoutSpy.mock.calls.map(([msg]) => String(msg)).join('')
+    expect(stdoutOutput).not.toContain('pageOptions')
+    expect(stdoutOutput).not.toContain('apiKey')
+    expect(stdoutOutput).not.toContain('dt_live_secret_should_never_be_printed')
+  })
+
+  it('emits JSON with data and pagination when --json is set', async () => {
+    mockClient()
+
+    await TypesList.run(['--json'])
+
+    const stdoutOutput = stdoutSpy.mock.calls.map(([msg]) => String(msg)).join('')
+    const parsed = JSON.parse(stdoutOutput)
+    expect(parsed.data).toHaveLength(1)
+    expect(parsed.data[0].codeType).toBe('invoice')
+    expect(parsed.pagination).toEqual({limit: 20, page: 1, total: 1})
+    expect(parsed).not.toHaveProperty('pageOptions')
+  })
+})


### PR DESCRIPTION
## Summary

- The SDK's `Page` class (returned by `documentTypes.list`) keeps `pageOptions` on the instance, which carries the API client and its `apiKey`. `JSON.stringify` serialized it through `outputJson`, exposing the apiKey on stdout for `docutray types list --json` (or piped).
- Fix at the call site (`types list` now passes `{data, pagination}` explicitly) and add a defense-in-depth `JSON.stringify` replacer in `outputJson` that drops `pageOptions` for any future paginated command.
- Bumps version to `0.3.1`.

## Impact

- Affected command in 0.3.0: `docutray types list` (with `--json` or when piped).
- Other commands return plain SDK response objects without `pageOptions` — not affected.
- Anyone who ran `types list` with non-interactive output should rotate their API key.

## Test plan

- [x] `npm test` — 153/153 pass, including a new regression test in `test/commands/types/list.test.ts` that asserts the JSON output contains neither `pageOptions` nor `apiKey`.
- [x] `npm run build`
- [ ] After merge: tag `v0.3.1` to trigger npm publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)