### PR TITLE
fix: types get/export now return jsonSchema (closes #32)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@docutray/cli",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@docutray/cli",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^4",
         "@oclif/plugin-autocomplete": "^3.2.45",
-        "docutray": "^0.1.2",
+        "docutray": "^0.1.3",
         "open": "^11.0.0"
       },
       "bin": {
@@ -4343,9 +4343,9 @@
       }
     },
     "node_modules/docutray": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/docutray/-/docutray-0.1.2.tgz",
-      "integrity": "sha512-QTV/QQ1/CxRyaU3I4dJ6tqdwC6cgl9vHKm0VGCbi7W6WusZBFK3/Jh729DvIGn2mWUENb0xgUIi/64rPPiK4pw==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/docutray/-/docutray-0.1.3.tgz",
+      "integrity": "sha512-Lp20H0VljI5M8FG5fZ67lB9Rs/8hv2mX6REGXfGIrPnIarxmGZD6KaqtC6i23vcAWBRoRUeM/oObPA8+iQUQNQ==",
       "license": "MIT",
       "engines": {
         "node": ">=20"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docutray/cli",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Official DocuTray CLI — AI-powered document processing from the command line",
   "author": "DocuTray",
   "license": "MIT",
@@ -62,7 +62,7 @@
   "dependencies": {
     "@oclif/core": "^4",
     "@oclif/plugin-autocomplete": "^3.2.45",
-    "docutray": "^0.1.2",
+    "docutray": "^0.1.3",
     "open": "^11.0.0"
   },
   "devDependencies": {

--- a/src/commands/types/get.ts
+++ b/src/commands/types/get.ts
@@ -14,8 +14,8 @@ export default class TypesGet extends BaseCommand {
 
   static examples = [
     {command: '<%= config.bin %> types get electronic-invoice', description: 'Get full details of a document type'},
-    {command: '<%= config.bin %> types get electronic-invoice --json', description: 'Output full JSON (includes field schema)'},
-    {command: '<%= config.bin %> types get electronic-invoice | jq .fields', description: 'Extract just the field schema (useful for scripts)'},
+    {command: '<%= config.bin %> types get electronic-invoice --json', description: 'Output full JSON (includes JSON Schema)'},
+    {command: '<%= config.bin %> types get electronic-invoice | jq .jsonSchema', description: 'Extract just the JSON Schema (useful for scripts)'},
   ]
 
   static flags = {
@@ -37,11 +37,22 @@ export default class TypesGet extends BaseCommand {
         {key: 'Description', value: result.description || '(none)'},
         {key: 'Public', value: result.isPublic ? 'yes' : 'no'},
         {key: 'Draft', value: result.isDraft ? 'yes' : 'no'},
-        {key: 'Fields', value: `${('fields' in result && Array.isArray(result.fields) ? result.fields.length : 0)} fields`},
+        {key: 'Schema', value: describeSchema(result.jsonSchema)},
       ])
     } catch (error) {
       outputError(error)
       this.exit(1)
     }
   }
+}
+
+function describeSchema(jsonSchema: Record<string, unknown> | null | undefined): string {
+  if (!jsonSchema) return '(none)'
+  const properties = jsonSchema.properties
+  if (properties && typeof properties === 'object') {
+    const count = Object.keys(properties as Record<string, unknown>).length
+    return `${count} top-level field${count === 1 ? '' : 's'}`
+  }
+
+  return '(present)'
 }

--- a/test/commands/types/export.test.ts
+++ b/test/commands/types/export.test.ts
@@ -10,24 +10,38 @@ vi.mock('node:fs', () => ({
   writeFileSync: vi.fn(),
 }))
 
-import {existsSync, statSync} from 'node:fs'
+import {existsSync, statSync, writeFileSync} from 'node:fs'
 import {createClient} from '../../../src/client.js'
 import TypesExport from '../../../src/commands/types/export.js'
 
 const mockCreateClient = vi.mocked(createClient)
 const mockExistsSync = vi.mocked(existsSync)
 const mockStatSync = vi.mocked(statSync)
+const mockWriteFileSync = vi.mocked(writeFileSync)
 
 function mockClient() {
   const client = {
     documentTypes: {
-      get: vi.fn().mockResolvedValue({codeType: 'invoice', name: 'Invoice', fields: []}),
+      // SDK 0.1.3+: get returns the unwrapped DocumentType including jsonSchema.
+      get: vi.fn().mockResolvedValue({
+        codeType: 'invoice',
+        description: 'Standard invoice',
+        id: 'cmnp1nxdb004s01tm5gxakfdl',
+        isDraft: false,
+        isPublic: true,
+        jsonSchema: {
+          properties: {total: {type: 'number'}},
+          type: 'object',
+        },
+        name: 'Invoice',
+        status: 'PUBLISHED',
+      }),
       list: vi.fn().mockResolvedValue({
         data: [{codeType: 'invoice', id: 'cmnp1nxdb004s01tm5gxakfdl', name: 'Invoice'}],
       }),
     },
   }
-  mockCreateClient.mockReturnValue(client as any)
+  mockCreateClient.mockReturnValue(client as never)
   return client
 }
 
@@ -82,5 +96,33 @@ describe('types export --force', () => {
     await expect(TypesExport.run(['invoice', '-o', './some-dir'])).rejects.toThrow('EXIT')
     expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('Output path is a directory: ./some-dir'))
     exitSpy.mockRestore()
+  })
+
+  it('writes jsonSchema and core fields to the output file', async () => {
+    mockClient()
+    mockExistsSync.mockReturnValue(false)
+
+    await TypesExport.run(['invoice', '-o', 'invoice.json'])
+
+    expect(mockWriteFileSync).toHaveBeenCalledTimes(1)
+    const [path, contents] = mockWriteFileSync.mock.calls[0]!
+    expect(path).toBe('invoice.json')
+    const parsed = JSON.parse(String(contents))
+    expect(parsed.codeType).toBe('invoice')
+    expect(parsed.name).toBe('Invoice')
+    expect(parsed.jsonSchema).toBeDefined()
+    expect(parsed.jsonSchema.properties).toHaveProperty('total')
+  })
+
+  it('emits flat JSON to stdout (no data wrapper) including jsonSchema', async () => {
+    mockClient()
+
+    await TypesExport.run(['invoice'])
+
+    const stdoutOutput = stdoutSpy.mock.calls.map(([msg]) => String(msg)).join('')
+    const parsed = JSON.parse(stdoutOutput)
+    expect(parsed).not.toHaveProperty('data')
+    expect(parsed.codeType).toBe('invoice')
+    expect(parsed.jsonSchema).toBeDefined()
   })
 })

--- a/test/commands/types/get.test.ts
+++ b/test/commands/types/get.test.ts
@@ -12,20 +12,32 @@ const mockCreateClient = vi.mocked(createClient)
 function mockClient() {
   const client = {
     documentTypes: {
+      // SDK 0.1.3+: documentTypes.get returns the unwrapped DocumentType
+      // (no `{data: ...}` wrapper) and includes `jsonSchema`.
       get: vi.fn().mockResolvedValue({
         codeType: 'invoice',
+        createdAt: '2026-01-01T00:00:00.000Z',
         description: 'Standard invoice',
-        fields: [{name: 'total'}],
+        id: 'cmnp1nxdb004s01tm5gxakfdl',
         isDraft: false,
         isPublic: true,
+        jsonSchema: {
+          properties: {
+            issuer: {type: 'string'},
+            total: {type: 'number'},
+          },
+          type: 'object',
+        },
         name: 'Invoice',
+        status: 'PUBLISHED',
+        updatedAt: '2026-01-02T00:00:00.000Z',
       }),
       list: vi.fn().mockResolvedValue({
         data: [{codeType: 'invoice', id: 'cmnp1nxdb004s01tm5gxakfdl', name: 'Invoice'}],
       }),
     },
   }
-  mockCreateClient.mockReturnValue(client as any)
+  mockCreateClient.mockReturnValue(client as never)
   return client
 }
 
@@ -61,12 +73,36 @@ describe('types get', () => {
     expect(client.documentTypes.get).toHaveBeenCalledWith('cmnp1nxdb004s01tm5gxakfdl')
   })
 
-  it('displays key-value output', async () => {
+  it('displays key-value output in TTY with real values (no undefined leaks)', async () => {
+    mockClient()
+    const originalIsTTY = process.stdout.isTTY
+    Object.defineProperty(process.stdout, 'isTTY', {configurable: true, value: true})
+
+    try {
+      await TypesGet.run(['invoice'])
+
+      const stdoutOutput = stdoutSpy.mock.calls.map(([msg]) => String(msg)).join('')
+      expect(stdoutOutput).toContain('invoice')
+      expect(stdoutOutput).toContain('Invoice')
+      expect(stdoutOutput).toContain('Standard invoice')
+      expect(stdoutOutput).toMatch(/Schema:\s+2 top-level fields/)
+      expect(stdoutOutput).not.toContain('undefined')
+    } finally {
+      Object.defineProperty(process.stdout, 'isTTY', {configurable: true, value: originalIsTTY})
+    }
+  })
+
+  it('emits flat JSON (no data wrapper) including jsonSchema when --json is set', async () => {
     mockClient()
 
-    await TypesGet.run(['invoice'])
+    await TypesGet.run(['invoice', '--json'])
 
-    expect(stdoutSpy).toHaveBeenCalled()
+    const stdoutOutput = stdoutSpy.mock.calls.map(([msg]) => String(msg)).join('')
+    const parsed = JSON.parse(stdoutOutput)
+    expect(parsed).not.toHaveProperty('data')
+    expect(parsed.codeType).toBe('invoice')
+    expect(parsed.jsonSchema).toBeDefined()
+    expect(parsed.jsonSchema.properties).toHaveProperty('total')
   })
 
   it('shows error when codeType not found', async () => {


### PR DESCRIPTION
## Summary

- Bumps SDK to `docutray@^0.1.3` (unwraps `{data}` from `documentTypes.get()`, renames `DocumentType.schema` → `jsonSchema`).
- Combined with backend [docutray/docutray#710](https://github.com/docutray/docutray/pull/710), `GET /api/document-types/:id` now returns the JSON Schema, so `types get` and `types export` can finally fulfill what their `--help` promises.
- `types get` renders real values in TTY (no more `Code: undefined`) and emits a flat JSON object including `jsonSchema`. The old `Fields: 0 fields` line is replaced with a `Schema:` summary derived from `jsonSchema.properties`.
- `types export` writes a JSON file with the full `DocumentType` including `jsonSchema`, suitable for backup/version-control/migration.
- Bumps version to `0.3.2`.

## Acceptance criteria (from #32)

- [x] `docutray types get <code>` in TTY shows real values for Code/Name/Description/Public/Draft.
- [x] `docutray types get <code>` in TTY shows the correct schema field count (no more `0 fields`).
- [x] `docutray types get <code> --json` emits the flat type object (no `data` wrapper) including `jsonSchema`.
- [x] `docutray types export <code> -o file.json` writes JSON with `jsonSchema`, sufficient to reconstruct the type.
- [x] `types get` test mocks the real SDK wire format and verifies renders.
- [x] `types export` test verifies file contents include `jsonSchema`.
- [x] Upstream blockers resolved: SDK [docutray-node#20](https://github.com/docutray/docutray-node/issues/20) (released as `docutray@0.1.3`) and backend [docutray#710](https://github.com/docutray/docutray/pull/710) (merged).

## Test plan

- [x] `npm run build`
- [x] `npm test` — 156/156 pass.
- [x] End-to-end: `docutray types get factura --json` against prod returns flat `DocumentType` with full `jsonSchema`.
- [ ] After merge: tag `v0.3.2` to trigger npm publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)